### PR TITLE
Added module directory to resource path so that images load when importi...

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -145,8 +145,11 @@ from kivy.metrics import dp
 from kivy.clock import Clock
 from kivy.properties import (ObjectProperty, NumericProperty, OptionProperty,
                              BooleanProperty, StringProperty)
-
+from kivy.resources import resource_add_path
 from kivy.lang import Builder
+import os.path
+
+resource_add_path(os.path.dirname(__file__))
 
 Builder.load_string('''
 <NavigationDrawer>:


### PR DESCRIPTION
I added the module directory to the kivy.resources so that when you import the module, the images for joinimage load. Currently, in my tests, the joinimage fails to load when importing garden.navigationdrawer because it defaults to looking in the application's directory for the images.

I'm not sure if this the preferred way to do it. Please check.

Thank you
