### PR TITLE
Added height checks to ensure touch is inside the nav drawer or its main panel

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -509,7 +509,10 @@ class NavigationDrawer(StencilView):
         if self._anim_progress < 0.001:  # i.e. closed
             valid_region = (self.x <=
                             touch.x <=
-                            (self.x + self.touch_accept_width))
+                            (self.x + self.touch_accept_width)) and \
+                           (self.y <=
+                            touch.y <=
+                            (self.y + self.height))
             if not valid_region:
                 self._main_panel.on_touch_down(touch)
                 return False
@@ -519,7 +522,10 @@ class NavigationDrawer(StencilView):
                 return False
             valid_region = (self._main_panel.x <=
                             touch.x <=
-                            (self._main_panel.x + self._main_panel.width))
+                            (self._main_panel.x + self._main_panel.width)) and \
+                           (self._main_panel.y <=
+                            touch.y <=
+                            (self._main_panel.y + self._main_panel.height))
             if not valid_region:
                 if self._main_above:
                     if col_main:


### PR DESCRIPTION
There is a bug in that the navigation drawer will grab touches which are vertically above or below it.

Referring to the image below, I've circled the button in the Android Gmail app which opens the Gmail navigation drawer.  In the previous implementation of Kivy's navigation drawer, it would be impossible to touch that button.  The navigation drawer did not perform checks on the touch's vertical position and would erroneously grab the touch.

![example](https://cloud.githubusercontent.com/assets/10732202/7167888/3cfe5bb8-e387-11e4-8fe7-caac54d311e1.png)
